### PR TITLE
feat: add 5 additive schema fields for ForgeTerrain high-priority features

### DIFF
--- a/fixtures/resolved_map.v1.example.json
+++ b/fixtures/resolved_map.v1.example.json
@@ -65,6 +65,82 @@
   },
   "consumed_fields": ["regions", "paths", "style_hints.boundary_softening"],
   "ignored_fields": ["style_hints.palette_override"],
+  "collisionGrid": {
+    "encoding": "rle",
+    "rows": [
+      "0:4",
+      "0:1,0:2,0:1",
+      "0:1,0:1,1:2",
+      "0:2,1:2"
+    ],
+    "legend": {
+      "0": "terrain",
+      "1": "obstacle"
+    }
+  },
+  "variantWeights": {
+    "grass": [
+      { "tileId": "grass_base", "weight": 1.0 },
+      { "tileId": "grass_v1", "weight": 0.3 }
+    ],
+    "dirt": [
+      { "tileId": "dirt_base", "weight": 1.0 },
+      { "tileId": "dirt_v1", "weight": 0.2 }
+    ],
+    "water": [
+      { "tileId": "water_base", "weight": 1.0 }
+    ]
+  },
+  "cellClassification": [
+    {
+      "x": 1, "y": 1,
+      "base": { "material": "dirt", "variant": "dirt_base", "variantRoll": 0.55 },
+      "transition": {
+        "boundary": ["dirt", "grass"],
+        "msCase": 8,
+        "cornerBits": "0001",
+        "hit": "exact",
+        "tileId": "dirt_grass_ms0001"
+      }
+    },
+    {
+      "x": 2, "y": 2,
+      "base": { "material": "water", "variant": "water_base", "variantRoll": 0.10 }
+    },
+    {
+      "x": 1, "y": 2,
+      "base": { "material": "grass", "variant": "grass_base", "variantRoll": 0.33 },
+      "transition": {
+        "boundary": ["dirt", "grass"],
+        "msCase": 6,
+        "cornerBits": "0110",
+        "hit": "transform",
+        "tileId": "dirt_grass_ms0001",
+        "sourceCase": 8,
+        "transform": "flipX"
+      },
+      "overlays": [
+        { "renderOrder": 10, "layerTag": "outline", "hit": "exact", "tileId": "grass_water_ms0110_outline" }
+      ]
+    }
+  ],
+  "layerManifest": [
+    {
+      "name": "terrain",
+      "index": 0,
+      "kind": "base",
+      "source": "variant-selection",
+      "description": "Base terrain layer with variant-selected tiles."
+    },
+    {
+      "name": "transition",
+      "index": 1,
+      "kind": "transition",
+      "renderOrder": 0,
+      "source": "marching-squares",
+      "description": "Transition tiles resolved via marching-squares."
+    }
+  ],
   "meta": {
     "coordSystem": "top-left",
     "tileSize": 16,

--- a/fixtures/terrain_pack.v1.example.json
+++ b/fixtures/terrain_pack.v1.example.json
@@ -105,5 +105,25 @@
     "dirt_water_ms0001": { "col": 2, "row": 1 },
     "grass_water_ms0110": { "col": 3, "row": 1 },
     "grass_water_ms0110_outline": { "col": 4, "row": 1 }
+  },
+  "materialProperties": {
+    "grass": {
+      "walkable": true,
+      "movementCost": 1.0,
+      "collisionGroup": "terrain",
+      "soundGroup": "grass"
+    },
+    "dirt": {
+      "walkable": true,
+      "movementCost": 1.2,
+      "collisionGroup": "terrain",
+      "soundGroup": "stone"
+    },
+    "water": {
+      "walkable": false,
+      "movementCost": 0,
+      "collisionGroup": "obstacle",
+      "soundGroup": "water"
+    }
   }
 }

--- a/schemas/resolved_map.v1.schema.json
+++ b/schemas/resolved_map.v1.schema.json
@@ -162,6 +162,72 @@
           "additionalProperties": true
         }
       }
+    },
+    "collisionGrid": {
+      "type": "object",
+      "description": "Derived collision/walkability grid. Cell values are integer IDs described by legend. Derived from material identity per cell and materialProperties from the terrain pack.",
+      "additionalProperties": false,
+      "required": ["encoding", "rows", "legend"],
+      "properties": {
+        "encoding": { "const": "rle" },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "^[0-9]+:[1-9][0-9]*(,[0-9]+:[1-9][0-9]*)*$" }
+        },
+        "legend": {
+          "type": "object",
+          "description": "Maps integer IDs to collision category names.",
+          "patternProperties": { "^[0-9]+$": { "type": "string", "minLength": 1 } },
+          "additionalProperties": false
+        }
+      }
+    },
+    "variantWeights": {
+      "type": "object",
+      "description": "Per-material variant weight table. Raw relative weights from the terrain pack (not normalized). Consumers normalize as needed.",
+      "patternProperties": {
+        "^[a-z][a-z0-9_-]*$": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tileId", "weight"],
+            "properties": {
+              "tileId": { "type": "string", "minLength": 1 },
+              "weight": { "type": "number", "exclusiveMinimum": 0 },
+              "themeId": { "type": "string", "minLength": 1, "description": "Theme tag, if this variant is theme-specific." }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "cellClassification": {
+      "type": "array",
+      "description": "Opt-in per-cell classification and resolution provenance. Sparse array — only boundary and notable cells included. Emitted when the composer is invoked with provenance: true.",
+      "items": {
+        "$ref": "#/$defs/cellClassificationEntry"
+      }
+    },
+    "layerManifest": {
+      "type": "array",
+      "description": "Structured metadata for each layer. Order matches layers[] array.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "index", "kind", "source"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "index": { "type": "integer", "minimum": 0, "description": "Index into the layers[] array." },
+          "kind": { "type": "string", "enum": ["base", "transition", "overlay", "emit", "clutter"] },
+          "renderOrder": { "type": "integer", "minimum": 0 },
+          "source": { "type": "string", "enum": ["variant-selection", "marching-squares", "materialEmits", "blue-noise", "wfc"], "description": "What produced this layer." },
+          "layerTag": { "type": "string", "description": "For overlays: the layerTag from the transition definition." },
+          "sourceMaterial": { "type": "string", "description": "For emit layers: the material whose materialEmits rule produced this layer." },
+          "description": { "type": "string", "description": "Human-readable description for tooling display." }
+        }
+      }
     }
   },
   "$defs": {
@@ -355,6 +421,76 @@
         },
         "levelIntentRef": {
           "type": "string"
+        }
+      }
+    },
+    "cellClassificationEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y"],
+      "properties": {
+        "x": { "type": "integer", "minimum": 0 },
+        "y": { "type": "integer", "minimum": 0 },
+        "base": {
+          "type": "object",
+          "description": "Base layer resolution info.",
+          "additionalProperties": false,
+          "properties": {
+            "material": { "type": "string" },
+            "variant": { "type": "string", "description": "Selected variant tileId." },
+            "variantRoll": { "type": "number", "description": "PRNG roll value (0-1) that selected this variant." }
+          }
+        },
+        "transition": {
+          "type": "object",
+          "description": "Transition layer resolution info.",
+          "additionalProperties": false,
+          "properties": {
+            "boundary": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 2 },
+            "msCase": { "type": "integer", "minimum": 0, "maximum": 15 },
+            "cornerBits": { "type": "string", "pattern": "^[01]{4}$" },
+            "hit": {
+              "type": "string",
+              "enum": ["exact", "transform", "gap"],
+              "description": "Resolution result: exact = tile found for this case, transform = tile found via transform equivalent (e.g., flipX of another case), gap = no matching tile found (missing asset)."
+            },
+            "tileId": { "type": "string" },
+            "sourceCase": { "type": "integer", "description": "Original MS case when hit is transform." },
+            "transform": { "type": "string", "description": "Transform applied when hit is transform." }
+          }
+        },
+        "overlays": {
+          "type": "array",
+          "description": "Overlay layer resolution info (one per renderOrder).",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "renderOrder": { "type": "integer" },
+              "layerTag": { "type": "string" },
+              "hit": {
+                "type": "string",
+                "enum": ["exact", "gap"],
+                "description": "Resolution result: exact = tile found for this case, gap = no matching tile (overlays do not use transform fallback)."
+              },
+              "tileId": { "type": "string" }
+            }
+          }
+        },
+        "emits": {
+          "type": "array",
+          "description": "Emit layer placement info.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "sourceMaterial": { "type": "string" },
+              "tileId": { "type": "string" },
+              "layer": { "type": "string" },
+              "dx": { "type": "integer" },
+              "dy": { "type": "integer" }
+            }
+          }
         }
       }
     }

--- a/schemas/terrain_pack.v1.schema.json
+++ b/schemas/terrain_pack.v1.schema.json
@@ -463,6 +463,23 @@
         }
       }
     },
+    "materialProperties": {
+      "type": "object",
+      "description": "Per-material gameplay metadata. Keys must match entries in materials[]. Values define known typed fields for common gameplay metadata. additionalProperties: true on inner objects is an intentional exception to the repo-wide convention — allows engine-specific and game-specific extensions without schema changes.",
+      "patternProperties": {
+        "^[a-z][a-z0-9_-]*$": {
+          "type": "object",
+          "properties": {
+            "walkable": { "type": "boolean", "description": "Whether this material is walkable." },
+            "movementCost": { "type": "number", "minimum": 0, "description": "Relative movement cost (1.0 = normal)." },
+            "collisionGroup": { "type": "string", "description": "Collision group identifier (e.g. terrain, obstacle, solid)." },
+            "soundGroup": { "type": "string", "description": "Footstep/ambient sound group (e.g. grass, stone, water)." }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
     "materialEmits": {
       "type": "object",
       "description": "Additional tile layers emitted per material. Keys are material IDs. For each map cell where that material is the base, emit rules place tiles into additional named layers at optional grid offsets.",

--- a/tests/validate-api-confidence.test.js
+++ b/tests/validate-api-confidence.test.js
@@ -76,6 +76,6 @@ describe('Validation API Confidence', () => {
     const hash = createHash('sha256')
       .update(JSON.stringify(resolvedMap))
       .digest('hex');
-    expect(hash).toBe('ebb34dc61afbdc5ffac8b5f1c3f8a251248ae123f97f464600ba454b2d8e6380');
+    expect(hash).toBe('435e08a46768a696d87eb964ad76784e92acb52243dbfcaca1d1a3e1bea2097f');
   });
 });


### PR DESCRIPTION
## Summary

Adds 5 optional, backward-compatible schema fields per [#13](https://github.com/Amerzel/ForgeContracts/issues/13):

| Schema | Field | Purpose |
|---|---|---|
| `terrain_pack.v1` | `materialProperties` | Per-material gameplay metadata (walkability, collision, sound) |
| `resolved_map.v1` | `collisionGrid` | Derived collision/walkability grid with RLE encoding |
| `resolved_map.v1` | `variantWeights` | Per-material variant weight table |
| `resolved_map.v1` | `cellClassification` | Opt-in per-cell classification provenance (sparse array) |
| `resolved_map.v1` | `layerManifest` | Structured layer metadata with `source` enum |

### Changes
- 2 schema files updated with new optional properties
- `cellClassificationEntry` added to `resolved_map.v1` `$defs`
- Both golden fixtures updated with representative example data
- Fixture hash updated in confidence test

### Design decisions (per issue discussion)
- `materialProperties` inner objects use `additionalProperties: true` (intentional escape hatch, documented in description)
- `layerManifest.source` is an enum: `variant-selection`, `marching-squares`, `materialEmits`, `blue-noise`, `wfc`
- `hit` field descriptions clarify `gap` semantics for transition vs overlay contexts

All existing tests pass. No breaking changes.

Closes #13