### PR TITLE
feat: add positions field to terrain_pack.v1 and resolved_map.v1 schemas

### DIFF
--- a/VOCABULARY.md
+++ b/VOCABULARY.md
@@ -209,3 +209,66 @@ Answers: "What tool created this document, and when?"
 Answers: "What source data was used to generate this document?"
 
 Both fields are optional. `producer` is defined by this vocabulary (all tools). `provenance` is tool-specific (currently used by TerrainComposer) and its shape varies by schema.
+
+---
+
+## 9. Transition Positions
+
+Transition entries in `terrain_pack.v1` and provenance records in `resolved_map.v1` use a `positions` array to identify which spatial locations around a tile have the secondary material present. This replaces the bit-encoded `cornerBits` string, which suffered from LSB-vs-MSB ambiguity across tools.
+
+### Position Vocabularies per Model
+
+Each tile model defines its own set of named positions:
+
+**Marching Squares (MS-14)** — 4 corner positions:
+
+```
+UL ──── UR
+│        │
+│  tile  │
+│        │
+DL ──── DR
+```
+
+Enum: `DL`, `DR`, `UL`, `UR`
+
+**Blob-47** — 8 neighbor directions:
+
+```
+NW   N   NE
+  ╲  │  ╱
+W ── ■ ── E
+  ╱  │  ╲
+SW   S   SE
+```
+
+Enum: `E`, `N`, `NE`, `NW`, `S`, `SE`, `SW`, `W`
+
+Corner directions (`NE`, `SE`, `SW`, `NW`) require both adjacent edges to be set.
+
+### Rules
+
+- **Array order:** `positions` arrays **MUST** be alphabetically sorted. Example: case 5 → `["DR", "UL"]`, not `["UL", "DR"]`.
+- **Uniqueness:** No duplicate entries. Schemas enforce `uniqueItems: true`.
+- **Case-sensitive:** Values are uppercase. Schemas enforce exact enum matching.
+- **Model-conditional validation:** The valid enum values depend on the `model` field. The schema uses `allOf` conditional blocks to validate the correct set per model.
+- **`caseId` retained:** The numeric `case` field remains as an internal implementation detail for mask generator lookups. It is not deprecated.
+
+### Field Authority During Migration
+
+During the dual-write migration period (v1 schemas), both `positions` and `cornerBits` may be present. The authority rule is:
+
+**`positions` is authoritative when present.** `cornerBits` exists solely for backward compatibility with consumers that have not yet adopted the named format.
+
+**Reader algorithm (all consumers):**
+
+1. If `positions` array is present → use it (authoritative)
+2. Else if `case` (caseId) is present → derive via `idToPositions(case, model)`
+3. Else if `cornerBits` is present → derive via `cornerBitsToId(bits, "lsb")` → `idToPositions()`
+4. Else → error (insufficient data)
+
+**Writer convention:** During dual-write, derive `positions` first (from the canonical case definition), then derive `cornerBits` from `positions` for backward compatibility. The named array is the source of truth at write time.
+
+### Why This Replaced `cornerBits`
+
+The bit-encoded `cornerBits` string had an inherent ambiguity: the compose pipeline wrote strings in LSB-first order (`[DR, UR, UL, DL]`), but JavaScript's `parseInt(raw, 2)` reads MSB-first. Different tools independently chose different conventions — the pack writer used LSB-first while the map resolver used `toString(2).padStart()` (MSB-first) — producing opposite strings for the same case without runtime failures (because the resolver keyed on numeric `caseId`). Named position arrays eliminate this class of encoding mismatch entirely.

--- a/fixtures/resolved_map.v1.example.json
+++ b/fixtures/resolved_map.v1.example.json
@@ -12,22 +12,60 @@
   },
   "seed": 42,
   "tileLookup": [
-    { "id": 0, "tileId": "grass_base", "material": "grass", "kind": "base" },
-    { "id": 1, "tileId": "dirt_base", "material": "dirt", "kind": "base" },
     {
-      "id": 2, "tileId": "water_base", "material": "water", "kind": "base",
+      "id": 0,
+      "tileId": "grass_base",
+      "material": "grass",
+      "kind": "base"
+    },
+    {
+      "id": 1,
+      "tileId": "dirt_base",
+      "material": "dirt",
+      "kind": "base"
+    },
+    {
+      "id": 2,
+      "tileId": "water_base",
+      "material": "water",
+      "kind": "base",
       "frameOffset": 0,
       "animation": {
         "frames": [
-          { "col": 4, "row": 0, "durationMs": 200 },
-          { "col": 5, "row": 0, "durationMs": 200 },
-          { "col": 6, "row": 0, "durationMs": 300 },
-          { "col": 7, "row": 0, "durationMs": 200 }
+          {
+            "col": 4,
+            "row": 0,
+            "durationMs": 200
+          },
+          {
+            "col": 5,
+            "row": 0,
+            "durationMs": 200
+          },
+          {
+            "col": 6,
+            "row": 0,
+            "durationMs": 300
+          },
+          {
+            "col": 7,
+            "row": 0,
+            "durationMs": 200
+          }
         ],
         "loop": true
       }
     },
-    { "id": 3, "tileId": "dirt_grass_ms0001", "kind": "transition", "boundary": ["dirt", "grass"], "transform": "none" }
+    {
+      "id": 3,
+      "tileId": "dirt_grass_ms0001",
+      "kind": "transition",
+      "boundary": [
+        "dirt",
+        "grass"
+      ],
+      "transform": "none"
+    }
   ],
   "layers": [
     {
@@ -63,8 +101,14 @@
     "semanticMapRef": "ashwood-forest_semantic.v1.json",
     "levelIntentRef": "ashwood-forest_intent.v1.json"
   },
-  "consumed_fields": ["regions", "paths", "style_hints.boundary_softening"],
-  "ignored_fields": ["style_hints.palette_override"],
+  "consumed_fields": [
+    "regions",
+    "paths",
+    "style_hints.boundary_softening"
+  ],
+  "ignored_fields": [
+    "style_hints.palette_override"
+  ],
   "collisionGrid": {
     "encoding": "rle",
     "rows": [
@@ -80,47 +124,95 @@
   },
   "variantWeights": {
     "grass": [
-      { "tileId": "grass_base", "weight": 1.0 },
-      { "tileId": "grass_v1", "weight": 0.3 }
+      {
+        "tileId": "grass_base",
+        "weight": 1.0
+      },
+      {
+        "tileId": "grass_v1",
+        "weight": 0.3
+      }
     ],
     "dirt": [
-      { "tileId": "dirt_base", "weight": 1.0 },
-      { "tileId": "dirt_v1", "weight": 0.2 }
+      {
+        "tileId": "dirt_base",
+        "weight": 1.0
+      },
+      {
+        "tileId": "dirt_v1",
+        "weight": 0.2
+      }
     ],
     "water": [
-      { "tileId": "water_base", "weight": 1.0 }
+      {
+        "tileId": "water_base",
+        "weight": 1.0
+      }
     ]
   },
   "cellClassification": [
     {
-      "x": 1, "y": 1,
-      "base": { "material": "dirt", "variant": "dirt_base", "variantRoll": 0.55 },
+      "x": 1,
+      "y": 1,
+      "base": {
+        "material": "dirt",
+        "variant": "dirt_base",
+        "variantRoll": 0.55
+      },
       "transition": {
-        "boundary": ["dirt", "grass"],
+        "boundary": [
+          "dirt",
+          "grass"
+        ],
         "msCase": 8,
         "cornerBits": "0001",
         "hit": "exact",
-        "tileId": "dirt_grass_ms0001"
+        "tileId": "dirt_grass_ms0001",
+        "positions": [
+          "DL"
+        ]
       }
     },
     {
-      "x": 2, "y": 2,
-      "base": { "material": "water", "variant": "water_base", "variantRoll": 0.10 }
+      "x": 2,
+      "y": 2,
+      "base": {
+        "material": "water",
+        "variant": "water_base",
+        "variantRoll": 0.1
+      }
     },
     {
-      "x": 1, "y": 2,
-      "base": { "material": "grass", "variant": "grass_base", "variantRoll": 0.33 },
+      "x": 1,
+      "y": 2,
+      "base": {
+        "material": "grass",
+        "variant": "grass_base",
+        "variantRoll": 0.33
+      },
       "transition": {
-        "boundary": ["dirt", "grass"],
+        "boundary": [
+          "dirt",
+          "grass"
+        ],
         "msCase": 6,
         "cornerBits": "0110",
         "hit": "transform",
         "tileId": "dirt_grass_ms0001",
         "sourceCase": 8,
-        "transform": "flipX"
+        "transform": "flipX",
+        "positions": [
+          "UL",
+          "UR"
+        ]
       },
       "overlays": [
-        { "renderOrder": 10, "layerTag": "outline", "hit": "exact", "tileId": "grass_water_ms0110_outline" }
+        {
+          "renderOrder": 10,
+          "layerTag": "outline",
+          "hit": "exact",
+          "tileId": "grass_water_ms0110_outline"
+        }
       ]
     }
   ],

--- a/fixtures/terrain_pack.v1.example.json
+++ b/fixtures/terrain_pack.v1.example.json
@@ -11,7 +11,11 @@
     "description": "Terrain pack for the Ashwood Forest zone in Emberfall",
     "author": "seedframe-team"
   },
-  "materials": ["dirt", "grass", "water"],
+  "materials": [
+    "dirt",
+    "grass",
+    "water"
+  ],
   "colorMap": {
     "dirt": "#8B6914",
     "grass": "#4A7C2E",
@@ -20,59 +24,112 @@
   "transitions": [
     {
       "id": "dirt-grass-ms01",
-      "boundary": ["dirt", "grass"],
+      "boundary": [
+        "dirt",
+        "grass"
+      ],
       "model": "marching-squares",
       "case": 8,
       "cornerBits": "0001",
       "tileId": "dirt_grass_ms0001",
-      "transform": "none"
+      "transform": "none",
+      "positions": [
+        "DL"
+      ]
     },
     {
       "id": "dirt-grass-ms02",
-      "boundary": ["dirt", "grass"],
+      "boundary": [
+        "dirt",
+        "grass"
+      ],
       "model": "marching-squares",
       "case": 6,
       "cornerBits": "0110",
       "tileId": "dirt_grass_ms0110",
-      "transform": "none"
+      "transform": "none",
+      "positions": [
+        "UL",
+        "UR"
+      ]
     },
     {
       "id": "dirt-water-ms01",
-      "boundary": ["dirt", "water"],
+      "boundary": [
+        "dirt",
+        "water"
+      ],
       "model": "marching-squares",
       "case": 8,
       "cornerBits": "0001",
       "tileId": "dirt_water_ms0001",
-      "transform": "none"
+      "transform": "none",
+      "positions": [
+        "DL"
+      ]
     },
     {
       "id": "grass-water-ms01",
-      "boundary": ["grass", "water"],
+      "boundary": [
+        "grass",
+        "water"
+      ],
       "model": "marching-squares",
       "case": 6,
       "cornerBits": "0110",
       "tileId": "grass_water_ms0110",
       "transform": "none",
-      "renderOrder": 0
+      "renderOrder": 0,
+      "positions": [
+        "UL",
+        "UR"
+      ]
     },
     {
       "id": "grass-water-ms01-outline",
-      "boundary": ["grass", "water"],
+      "boundary": [
+        "grass",
+        "water"
+      ],
       "model": "marching-squares",
       "case": 6,
       "cornerBits": "0110",
       "tileId": "grass_water_ms0110_outline",
       "transform": "none",
       "renderOrder": 10,
-      "layerTag": "outline"
+      "layerTag": "outline",
+      "positions": [
+        "UL",
+        "UR"
+      ]
     }
   ],
   "variants": [
-    { "tileId": "grass_base", "material": "grass", "weight": 1.0 },
-    { "tileId": "grass_v1", "material": "grass", "weight": 0.3 },
-    { "tileId": "dirt_base", "material": "dirt", "weight": 1.0 },
-    { "tileId": "dirt_v1", "material": "dirt", "weight": 0.2 },
-    { "tileId": "water_base", "material": "water", "weight": 1.0 }
+    {
+      "tileId": "grass_base",
+      "material": "grass",
+      "weight": 1.0
+    },
+    {
+      "tileId": "grass_v1",
+      "material": "grass",
+      "weight": 0.3
+    },
+    {
+      "tileId": "dirt_base",
+      "material": "dirt",
+      "weight": 1.0
+    },
+    {
+      "tileId": "dirt_v1",
+      "material": "dirt",
+      "weight": 0.2
+    },
+    {
+      "tileId": "water_base",
+      "material": "water",
+      "weight": 1.0
+    }
   ],
   "atlas": {
     "image": "ashwood-forest.png",
@@ -81,30 +138,74 @@
     "rows": 8
   },
   "tileIndex": {
-    "grass_base": { "col": 0, "row": 0 },
-    "grass_v1": { "col": 1, "row": 0 },
-    "dirt_base": { "col": 2, "row": 0 },
-    "dirt_v1": { "col": 3, "row": 0 },
+    "grass_base": {
+      "col": 0,
+      "row": 0
+    },
+    "grass_v1": {
+      "col": 1,
+      "row": 0
+    },
+    "dirt_base": {
+      "col": 2,
+      "row": 0
+    },
+    "dirt_v1": {
+      "col": 3,
+      "row": 0
+    },
     "water_base": {
-      "col": 4, "row": 0,
+      "col": 4,
+      "row": 0,
       "frameCount": 4,
       "frameDurationMs": 200,
       "animation": {
         "frames": [
-          { "col": 4, "row": 0, "durationMs": 200 },
-          { "col": 5, "row": 0, "durationMs": 200 },
-          { "col": 6, "row": 0, "durationMs": 300 },
-          { "col": 7, "row": 0, "durationMs": 200 }
+          {
+            "col": 4,
+            "row": 0,
+            "durationMs": 200
+          },
+          {
+            "col": 5,
+            "row": 0,
+            "durationMs": 200
+          },
+          {
+            "col": 6,
+            "row": 0,
+            "durationMs": 300
+          },
+          {
+            "col": 7,
+            "row": 0,
+            "durationMs": 200
+          }
         ],
         "loop": true,
         "label": "ripple"
       }
     },
-    "dirt_grass_ms0001": { "col": 0, "row": 1 },
-    "dirt_grass_ms0110": { "col": 1, "row": 1 },
-    "dirt_water_ms0001": { "col": 2, "row": 1 },
-    "grass_water_ms0110": { "col": 3, "row": 1 },
-    "grass_water_ms0110_outline": { "col": 4, "row": 1 }
+    "dirt_grass_ms0001": {
+      "col": 0,
+      "row": 1
+    },
+    "dirt_grass_ms0110": {
+      "col": 1,
+      "row": 1
+    },
+    "dirt_water_ms0001": {
+      "col": 2,
+      "row": 1
+    },
+    "grass_water_ms0110": {
+      "col": 3,
+      "row": 1
+    },
+    "grass_water_ms0110_outline": {
+      "col": 4,
+      "row": 1
+    }
   },
   "materialProperties": {
     "grass": {

--- a/schemas/resolved_map.v1.schema.json
+++ b/schemas/resolved_map.v1.schema.json
@@ -448,7 +448,13 @@
           "properties": {
             "boundary": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 2 },
             "msCase": { "type": "integer", "minimum": 0, "maximum": 15 },
-            "cornerBits": { "type": "string", "pattern": "^[01]{4}$" },
+            "cornerBits": { "type": "string", "description": "Deprecated: prefer the positions array. Will be removed in resolved_map.v2.", "pattern": "^[01]{4}$" },
+            "positions": {
+              "type": "array",
+              "description": "Named spatial positions indicating which corners have the secondary material. Alphabetically sorted. Authoritative when present — see VOCABULARY.md §9.",
+              "items": { "type": "string", "enum": ["DL", "DR", "UL", "UR"] },
+              "uniqueItems": true
+            },
             "hit": {
               "type": "string",
               "enum": ["exact", "transform", "gap"],

--- a/schemas/terrain_pack.v1.schema.json
+++ b/schemas/terrain_pack.v1.schema.json
@@ -320,8 +320,14 @@
           },
           "cornerBits": {
             "type": "string",
-            "description": "Bit-string encoding which corners belong to the secondary material. Character order is DR(bit0), UR(bit1), UL(bit2), DL(bit3) for 4-bit marching squares. The numeric `case` value is computed by reversing this string and parsing as binary (e.g. cornerBits \"0001\" → reversed \"1000\" → case 8).",
+            "description": "Deprecated: prefer the `positions` array. Bit-string encoding which corners belong to the secondary material. Character order is DR(bit0), UR(bit1), UL(bit2), DL(bit3) for 4-bit marching squares. The numeric `case` value is computed by reversing this string and parsing as binary (e.g. cornerBits \"0001\" → reversed \"1000\" → case 8). Will be removed in terrain_pack.v2.",
             "pattern": "^[01]{4,8}$"
+          },
+          "positions": {
+            "type": "array",
+            "description": "Named spatial positions indicating which locations around the tile have the secondary material. Values are model-specific: marching-squares uses corner positions (DL, DR, UL, UR), blob-47 uses 8-neighbor directions (E, N, NE, NW, S, SE, SW, W). Alphabetically sorted. Authoritative when present — see VOCABULARY.md §9.",
+            "items": { "type": "string" },
+            "uniqueItems": true
           },
           "ruleId": {
             "type": "string"
@@ -375,7 +381,12 @@
               "required": ["model"]
             },
             "then": {
-              "required": ["case", "cornerBits"]
+              "required": ["case", "cornerBits"],
+              "properties": {
+                "positions": {
+                  "items": { "enum": ["DL", "DR", "UL", "UR"] }
+                }
+              }
             }
           },
           {
@@ -384,7 +395,12 @@
               "required": ["model"]
             },
             "then": {
-              "required": ["case", "cornerBits"]
+              "required": ["case", "cornerBits"],
+              "properties": {
+                "positions": {
+                  "items": { "enum": ["E", "N", "NE", "NW", "S", "SE", "SW", "W"] }
+                }
+              }
             }
           },
           {

--- a/schemas/terrain_pack.v1.schema.json
+++ b/schemas/terrain_pack.v1.schema.json
@@ -409,7 +409,12 @@
               "required": ["model"]
             },
             "then": {
-              "required": ["wangCode"]
+              "required": ["wangCode"],
+              "properties": {
+                "positions": {
+                  "items": { "enum": ["E", "N", "S", "W"] }
+                }
+              }
             }
           },
           {

--- a/tests/validate-api-confidence.test.js
+++ b/tests/validate-api-confidence.test.js
@@ -76,6 +76,6 @@ describe('Validation API Confidence', () => {
     const hash = createHash('sha256')
       .update(JSON.stringify(resolvedMap))
       .digest('hex');
-    expect(hash).toBe('435e08a46768a696d87eb964ad76784e92acb52243dbfcaca1d1a3e1bea2097f');
+    expect(hash).toBe('6837618003afc634cb58dbf3a20aa9ea846ad429cad1c37356066e7c22dc148d');
   });
 });


### PR DESCRIPTION
## Summary

Implements [ForgeContracts#15](https://github.com/Amerzel/ForgeContracts/issues/15) per [Forge#234](https://github.com/Amerzel/Forge/issues/234) RFC.

Adds an optional `positions` array field to transition entries, replacing the opaque bit-encoded `cornerBits` string with explicit named spatial positions. This is a **Phase 1** change — additive optional fields only, no breaking changes.

## Changes

### Schemas

- **`terrain_pack.v1.schema.json`**: Added optional `positions` field (string array, `uniqueItems: true`) to transition entries. Model-conditional enum validation via existing `allOf` blocks:
  - `marching-squares` → `["DL", "DR", "UL", "UR"]`
  - `blob-47` → `["E", "N", "NE", "NW", "S", "SE", "SW", "W"]`
- **`resolved_map.v1.schema.json`**: Added optional `positions` to `cellClassificationEntry.transition` with MS enum constraint (this definition is implicitly MS-only via `msCase`).
- Marked `cornerBits` description as deprecated in both schemas.

### Documentation

- **`VOCABULARY.md` §9**: New section covering position vocabularies per model (with spatial diagrams), alphabetical sort convention, concrete 3-step reader algorithm, field authority during migration, and rationale for the change.

### Fixtures & Tests

- Added `positions` arrays to all transition entries in `fixtures/terrain_pack.v1.example.json` and `fixtures/resolved_map.v1.example.json`.
- Updated golden fixture hash in `validate-api-confidence.test.js`.
- Regenerated TypeScript types in `dist/types/`.

## Backward Compatibility

- **Strictly additive.** No existing valid document becomes invalid.
- `cornerBits` remains required for `marching-squares` and `blob-47` models in v1.
- `positions` is optional in v1; the requirement flip happens at v2.
- During dual-write, `positions` is authoritative when present (see VOCABULARY.md §9).

## Test Results

- ✅ 82/82 tests passing
- ✅ Smoke: 16/16 fixtures validated

## Unblocks

- [ForgeTileset#36](https://github.com/Amerzel/ForgeTileset/issues/36) — tileset-core helpers + writer dual-write (Phase 2)
- [ForgeTerrain#54](https://github.com/Amerzel/ForgeTerrain/issues/54) — reader adoption (Phase 3)
- [ForgeAsset#10](https://github.com/Amerzel/ForgeAsset/issues/10) — reader adoption (Phase 3)

Closes #15